### PR TITLE
fix solr cloud upload and ansible lint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Role Variables
 
   - `solr_service_start` - to start solr service in the end of role/Playbook
 
-    default: `True`
+    default: `true`
 
  - `solr_base_path` - path to solr base
 
@@ -80,11 +80,11 @@ Role Variables
      default: `- default`
    - `auto_populate_configset_list` - get all configset directories automatically
 
-     default: `True`
+     default: `true`
 
    - `zk_enable_ssl` - set zookeepers to communicate with solr by ssl
 
-      default: `True`
+      default: `true`
 
    - `zk_hosts_list` - list of zookeeper hosts
 
@@ -121,7 +121,7 @@ Example Playbook
   hosts: solr
   vars:
     solr_version: 7.7.1
-    solr_change_default_password: False
+    solr_change_default_password: false
   roles:
     - role: lean_delivery.java
     - role: lean_delivery.solr_standalone
@@ -130,7 +130,7 @@ Example Playbook
       zk_inventory_group: zookeeper
       configset_list:
         - default
-      auto_populate_configset_list: False
+      auto_populate_configset_list: false
 ```
 
 ```yml
@@ -147,15 +147,15 @@ Example Playbook
   roles:
     - role: lean_delivery.java
     - role: lean_delivery.solr_standalone
-      solr_change_default_password: False
-      solr_auth_configure: False
-      solr_ssl_configure: False
+      solr_change_default_password: false
+      solr_auth_configure: false
+      solr_ssl_configure: false
     - role: lean_delivery.solr_cloud
       zk_inventory_group: zookeeper
       configset_list:
         - default
-      auto_populate_configset_list: False
-      zk_enable_ssl: False
+      auto_populate_configset_list: false
+      zk_enable_ssl: false
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ solr_version: 8.0.0
 solr_insh_default: /etc/default/solr.in.sh
 
 solr_service_name: solr
-solr_service_start: True
+solr_service_start: true
 solr_base_path: /var/solr
 solr_home: '{{ solr_base_path }}/data'
 
@@ -18,7 +18,7 @@ zk_inventory_group: ''
 zk_client_port: 2181
 configset_list:
   - default
-auto_populate_configset_list: True
-zk_enable_ssl: True
+auto_populate_configset_list: true
+zk_enable_ssl: true
 zk_hosts_list: '{{ groups[zk_inventory_group] | map("extract", hostvars, ["ansible_default_ipv4","address"]) | list }}'
 solr_host_naming: '{{ ansible_fqdn }}'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,6 @@
   systemd:
     name: '{{ solr_service_name }}'
     state: restarted
-  become: True
+  become: true
   when:
   - solr_service_start

--- a/molecule/cloud-aws-direct/molecule.yml
+++ b/molecule/cloud-aws-direct/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     instance_type: m5.large
     region: us-east-1
     vpc_subnet_id: subnet-05a2ef2b767afec50
-    assign_public_ip: False
+    assign_public_ip: false
     spot_price: 0.04
     security_group_name:
       - default
@@ -31,7 +31,7 @@ platforms:
     instance_type: m5.large
     region: us-east-1
     vpc_subnet_id: subnet-05a2ef2b767afec50
-    assign_public_ip: False
+    assign_public_ip: false
     security_group_name:
       - default
     spot_price: 0.04
@@ -47,7 +47,7 @@ platforms:
     instance_type: m5.large
     region: us-east-1
     vpc_subnet_id: subnet-05a2ef2b767afec50
-    assign_public_ip: False
+    assign_public_ip: false
     security_group_name:
       - default
     spot_price: 0.04
@@ -62,7 +62,7 @@ platforms:
     instance_type: m5.large
     region: us-east-1
     vpc_subnet_id: subnet-05a2ef2b767afec50
-    assign_public_ip: False
+    assign_public_ip: false
     spot_price: 0.04
     security_group_name:
       - default
@@ -75,7 +75,7 @@ platforms:
 
 provisioner:
   name: ansible
-  log: False
+  log: false
   inventory:
     group_vars:
       all:

--- a/molecule/cloud-aws-direct/playbook.yml
+++ b/molecule/cloud-aws-direct/playbook.yml
@@ -1,7 +1,7 @@
 ---
 - name: Force gathering facts
   hosts: all
-  gather_facts: True
+  gather_facts: true
   roles: []
 
 - name: Configure Solr Cloud
@@ -9,5 +9,5 @@
   roles:
     - role: ansible-role-solr-cloud
       zk_inventory_group: zookeeper
-      auto_populate_configset_list: True
-      zk_enable_ssl: False
+      auto_populate_configset_list: true
+      zk_enable_ssl: false

--- a/molecule/cloud-epc-delegated/molecule.yml
+++ b/molecule/cloud-epc-delegated/molecule.yml
@@ -39,7 +39,7 @@ platforms:
       - solr
 provisioner:
   name: ansible
-  log: True
+  log: true
   inventory:
     group_vars:
       all:

--- a/molecule/cloud-epc-delegated/playbook.yml
+++ b/molecule/cloud-epc-delegated/playbook.yml
@@ -1,7 +1,7 @@
 ---
 - name: Force gathering facts
   hosts: all
-  gather_facts: True
+  gather_facts: true
   roles: []
 
 - name: Configure Solr Cloud
@@ -9,5 +9,5 @@
   roles:
     - role: ansible-role-solr-cloud
       zk_inventory_group: zookeeper
-      auto_populate_configset_list: True
-      zk_enable_ssl: False
+      auto_populate_configset_list: true
+      zk_enable_ssl: false

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,21 +12,21 @@ lint:
 platforms:
   - name: test-docker-centos7-solr-cloud-1
     image: leandelivery/docker-systemd:centos7
-    privileged: True
+    privileged: true
     groups:
       - rhel_family
       - zookeeper
       - solr
   - name: test-docker-centos7-solr-cloud-2
     image: leandelivery/docker-systemd:centos7
-    privileged: True
+    privileged: true
     groups:
       - rhel_family
       - zookeeper
       - solr
   - name: test-docker-ubuntu1804-solr-cloud
     image: leandelivery/docker-systemd:ubuntu-18.04
-    privileged: True
+    privileged: true
     security_opts:
       - seccomp=unconfined
     volumes:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,7 +1,7 @@
 ---
 - name: Force gathering facts
   hosts: all
-  gather_facts: True
+  gather_facts: true
   roles: []
 
 - name: Configure Solr Cloud
@@ -9,5 +9,5 @@
   roles:
     - role: ansible-role-solr-cloud
       zk_inventory_group: zookeeper
-      auto_populate_configset_list: True
-      zk_enable_ssl: False
+      auto_populate_configset_list: true
+      zk_enable_ssl: false

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -1,13 +1,13 @@
 ---
 - name: Prepare Ubuntu / Debian
   hosts: debian_family
-  gather_facts: False
+  gather_facts: false
   tasks:
 
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (apt install -y python-minimal)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false
       register: update_result
       retries: 10
       delay: 5
@@ -15,12 +15,12 @@
 
 - name: Prepare RHEL
   hosts: rhel_family
-  gather_facts: False
+  gather_facts: false
   tasks:
     - name: Install python for Ansible
       raw: test -e /usr/bin/python || (yum install -y python2 python-simplejson)
-      become: True
-      changed_when: False
+      become: true
+      changed_when: false
 
     - name: gather facts
       setup:
@@ -32,7 +32,7 @@
         state: 'present'
       register: status
       until: status is succeeded
-      become: True
+      become: true
 
 - name: Prepare java
   hosts: all
@@ -49,8 +49,8 @@
   roles:
    - role: lean_delivery.solr_standalone
   vars:
-    solr_change_default_password: False
-    solr_auth_configure: False
-    solr_use_java_version_8: False
-    solr_ssl_configure: False
+    solr_change_default_password: false
+    solr_auth_configure: false
+    solr_use_java_version_8: false
+    solr_ssl_configure: false
     solr_ssl_check_peer_name: 'false'

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -57,6 +57,8 @@
     - zk_hosts | length
 
 - name: Solr Cloud upload config
+  environment:
+    SOLR_ENV: "{{ solr_insh_default }}"
   command: >-
     {{ solr_dest_path }}/bin/solr zk -upconfig -n {{ solr_conf_set }}
     -d '{{ solr_configset_path }}/{{ solr_conf_set | basename }}/conf'

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -5,7 +5,7 @@
   loop: '{{ zk_hosts_list }}'
   loop_control:
     loop_var: host
-  run_once: True
+  run_once: true
 
 - name: Replace zookeeper configuration
   lineinfile:
@@ -19,7 +19,7 @@
       zk_line: 'SOLR_HOST="{{ solr_host_naming }}"'
   loop_control:
     loop_var: zk_insh_config
-  become: True
+  become: true
   when:
     - zk_hosts | length
   notify:
@@ -34,16 +34,16 @@
     -val {{ solr_ssl_enabled }}
   args:
     removes: '{{ solr_dest_path }}/server/scripts/cloud-scripts/zkcli.sh'
-  run_once: True
-  changed_when: False
+  run_once: true
+  changed_when: false
 
 - name: Set configset list
   find:
     paths: '{{ solr_configset_path }}'
     file_type: directory
   register: configset_output
-  run_once: True
-  become: True
+  run_once: true
+  become: true
   when:
     - auto_populate_configset_list
     - zk_hosts | length
@@ -63,17 +63,17 @@
   loop: '{{ configset_list }}'
   loop_control:
     loop_var: solr_conf_set
-  run_once: True
+  run_once: true
   when:
     - zk_hosts | length
     - configset_list | length
-  changed_when: False
+  changed_when: false
 
 - name: Start service
   service:
     name: '{{ solr_service_name }}'
     state: started
-    enabled: True
-  become: True
+    enabled: true
+  become: true
   when:
     - solr_service_start


### PR DESCRIPTION
set SOLR_ENV to solr_insh_default for cloud upload task to enforce solr command to use the correct solr environment

fix lint warnings due to capitalized true and false 